### PR TITLE
Improve symbol update queue resilience

### DIFF
--- a/MQL5/Experts/VelocityTrader_v7_1_Duel.mq5
+++ b/MQL5/Experts/VelocityTrader_v7_1_Duel.mq5
@@ -630,11 +630,16 @@ void OnTick()
          // MEDIUM/LOW priority: queue for deferred processing
          else if(priority <= PRIORITY_LOW)
          {
-            g_perfManager.updateQueue.Enqueue(i, (int)priority);
+            if(!g_perfManager.updateQueue.Enqueue(i, (int)priority))
+            {
+               // Queue is saturated — fall back to inline update to avoid stale data
+               UpdateSymbol(i);
+               g_perfManager.OnSymbolUpdated();
+            }
          }
          // IDLE priority: skip, will be updated in OnTimer
       }
-   }
+      }
 
    // ════════════════════════════════════════════════════════════════
    // UPDATE PRIORITIES: Based on current state


### PR DESCRIPTION
## Summary
- expand the async symbol-update queue and track dropped enqueue attempts for diagnostics
- fall back to inline updates when the queue is saturated to keep symbol data fresh
- expose queue depth and drop counts in performance statistics output

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d6bfaae8c83328a722f20e0dafe46)